### PR TITLE
[DevOps] fix client release + try GCP credentials

### DIFF
--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -77,6 +77,10 @@ jobs:
         run: echo "$ANSIBLE_VAULT" > ~/.vault.txt
         env:
           ANSIBLE_VAULT: ${{ secrets.ANSIBLE_VAULT }}
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
       - name: Run Packer
         run: |
           cd devops/packer

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -77,6 +77,10 @@ jobs:
         run: echo "$ANSIBLE_VAULT" > ~/.vault.txt
         env:
           ANSIBLE_VAULT: ${{ secrets.ANSIBLE_VAULT }}
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
       - name: Run Packer
         run: |
           cd devops/packer


### PR DESCRIPTION
- The client workflow was building backend - fixed
- Packer was failing on GCP credentials - try GHA action to deal with it