### PR TITLE
Secrets dir used outside of ssl tasks

### DIFF
--- a/devops/ansible/roles/ivynet-backend/tasks/main.yml
+++ b/devops/ansible/roles/ivynet-backend/tasks/main.yml
@@ -13,6 +13,17 @@
   tags:
     - general
 
+- name: Set secrets directory
+  ansible.builtin.file:
+    path: "{{ ivynet_backend_path_secrets }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  tags:
+    - general
+    - ssl
+
 - name: Install and configure 3rd party tools
   ansible.builtin.import_tasks:
     file: third_party.yml

--- a/devops/ansible/roles/ivynet-backend/tasks/ssl.yml
+++ b/devops/ansible/roles/ivynet-backend/tasks/ssl.yml
@@ -1,14 +1,4 @@
 ---
-- name: Set  directory
-  ansible.builtin.file:
-    path: "{{ ivynet_backend_path_secrets }}"
-    state: directory
-    owner: root
-    group: root
-    mode: "0700"
-  tags:
-    - ssl
-
 - name: Check if pem file exists
   ansible.builtin.stat:
     path: "{{ ivynet_backend_path_secrets }}/self.pem"


### PR DESCRIPTION
We use the secrets for env along ssl, so it has to be created earlier