### PR TITLE
Move tagging onto the master branch

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -6,7 +6,7 @@ on:
     types:
       - closed
     branches:
-      - dev
+      - master
 
 
 permissions:


### PR DESCRIPTION
It looks like the only required change for branching master. Later, I'm going to look at extra actions for dev (e.g. deployment to api3).