### PR TITLE
Adding old running metric back in temp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "ivynet-backend"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "axum",
  "axum-extra",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-backend"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This pull request includes changes to the `ivynet-backend` package to update its version and add a new function to handle AVS data. The most important changes are updating the package version and adding the `setup_avs_old` function to the backend service.

Version update:

* [`backend/Cargo.toml`](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L3-R3): Updated the package version from `0.4.15` to `0.4.16`.

Backend service enhancements:

* [`backend/src/grpc/backend.rs`](diffhunk://#diff-b6dac0f4120feaba78cb69f9fb55d8135b03b106536edea576c8810944fa0e33R179-R182): Added a call to the new `setup_avs_old` function in the `impl Backend for BackendService` block to handle AVS data and save metrics.
* [`backend/src/grpc/backend.rs`](diffhunk://#diff-b6dac0f4120feaba78cb69f9fb55d8135b03b106536edea576c8810944fa0e33R239-R291): Defined the `setup_avs_old` function to process AVS data from the client and record it in the database.