### PR TITLE
[IV-188] Prepare for release branches 2

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -6,8 +6,7 @@ on:
     types:
       - closed
     branches:
-      - master
-
+      - release-*
 
 permissions:
   id-token: write  # This is required for requesting the JWT

--- a/.github/workflows/devops-test.yml
+++ b/.github/workflows/devops-test.yml
@@ -6,6 +6,7 @@ on:
     branches-ignore:
       - dev
       - master
+      - release-*
     paths:
       - .github/**
       - devops/**


### PR DESCRIPTION
This is a cherry-pick of changes applied to dev. They are now going to release branch. Not sure if that required for GHA, but don't want to be surprise if we need them to run the release steps.