### PR TITLE
local tagging quick fix

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -229,22 +229,5 @@ async fn update_node_data_versions(pool: &PgPool, chain: &Chain) -> Result<(), B
         }
     }
 
-    db::DbAvsVersionData::set_avs_version(
-        pool,
-        &NodeType::Brevis,
-        &Chain::Holesky,
-        "Local",
-        "local_build_only",
-    )
-    .await?;
-    db::DbAvsVersionData::set_avs_version(
-        pool,
-        &NodeType::Brevis,
-        &Chain::Mainnet,
-        "Local",
-        "local_build_only",
-    )
-    .await?;
-
     Ok(())
 }

--- a/core/src/telemetry/mod.rs
+++ b/core/src/telemetry/mod.rs
@@ -79,7 +79,6 @@ pub struct ConfiguredAvs {
  *    handle and is spawned as a future in the listen function.
  *
  */
-
 pub async fn listen(
     backend_client: BackendClient<Channel>,
     machine_id: Uuid,

--- a/db/src/data/avs_version.rs
+++ b/db/src/data/avs_version.rs
@@ -138,7 +138,7 @@ pub async fn find_latest_avs_version(
                 None => (tag, digest),
             }
         }
-        VersionType::LocalOnly => return Err(DatabaseError::LocalOnlyNode),
+        VersionType::LocalOnly => ("Local".to_string(), "Local_Builds_Only".to_string()),
     };
     Ok((tag, digest))
 }


### PR DESCRIPTION
This pull request includes several changes to the codebase, focusing on updating node data versions, cleaning up the telemetry module, and adjusting the handling of local-only version types. The most important changes include removing redundant database update calls, cleaning up whitespace, and modifying error handling for local-only version types.

Key changes:

### Node Data Version Updates:
* [`backend/src/main.rs`](diffhunk://#diff-03f0e815a03d93163cd4716a8ce1b5721eb199510b81334e5f5c1ae63af4704dL232-L248): Removed redundant calls to `db::DbAvsVersionData::set_avs_version` for `NodeType::Brevis` and `Chain::Holesky` and `Chain::Mainnet`.

### Telemetry Module Cleanup:
* [`core/src/telemetry/mod.rs`](diffhunk://#diff-185f66008823ea53894239cec5b7249a9e9567747ee74e00868b1fbc10303c08L82): Removed unnecessary whitespace in the `listen` function.

### Local-Only Version Handling:
* [`db/src/data/avs_version.rs`](diffhunk://#diff-ed1951db49cc0ee01924c8e73980c255dc0a20f0ac45f53ca0c52b82fde314caL141-R141): Modified the `find_latest_avs_version` function to return a tuple with "Local" and "Local_Builds_Only" strings instead of an error for `VersionType::LocalOnly`.