### PR TITLE
primev update

### DIFF
--- a/ivynet-node-type/src/lib.rs
+++ b/ivynet-node-type/src/lib.rs
@@ -457,6 +457,8 @@ impl NodeType {
             NUFFLE_REPO => Some(Self::Nuffle),
             PRIMEV_LOCAL_REPO => Some(Self::PrimevMevCommit),
             PRIMEV_IMAGE_REPO => Some(Self::PrimevMevCommit),
+            GOPLUS_REPO => Some(Self::GoPlusAVS),
+            OMNI_REPO => Some(Self::Omni),
             _ => None,
         }
     }
@@ -479,7 +481,7 @@ impl NodeType {
             AUTOMATA_OPERATOR => Self::Automata,
             AUTOMATA_OPERATOR_HOLESKY => Self::Automata,
             AVA_OPERATOR => Self::AvaProtocol,
-            CHAINBASE_NETWORK_V1_NODE => Self::ChainbaseNetworkV1,
+            CHAINBASE_NETWORK_V1_NODE => Self::ChainbaseNetwork,
             GOPLUS_CONTAINER_NAME => Self::GoPlusAVS,
             LAGRANGE_WORKER_CONTAINER_NAME => Self::LagrangeZkWorker,
             LAGRANGE_STATE_COMMITTEE_CONTAINER_NAME => Self::LagrangeStateCommittee,


### PR DESCRIPTION
This pull request includes several changes to the `ivynet-node-type/src/lib.rs` file, primarily adding and modifying constants and match arms for the `PrimevMevCommit` node type. The most important changes include the addition of new constants for repositories and container names, and updates to the `NodeType` implementation to handle these new constants.

### Additions and Modifications to Constants:

* Added `PRIMEV_LOCAL_REPO` and `PRIMEV_IMAGE_REPO` constants for repository URLs.
* Added `PRIMEV_MEV_COMMIT_CONTAINER_NAME` constant for container names.

### Updates to `NodeType` Implementation:

* Added `PrimevMevCommit` match arm for repository handling.
* Added `PrimevMevCommit` match arm for container name handling. [[1]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R281) [[2]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R343)
* Updated match arms to include `PrimevMevCommit` in error handling and default cases. [[1]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3L297) [[2]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3L368)
* Included `PrimevMevCommit` in repository and container name mappings. [[1]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R458-R459) [[2]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R495)