### PR TITLE
logs time constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,7 +2760,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "ivynet-backend"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "axum",
  "axum-extra",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-backend"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This pull request includes several changes to the `ivynet-backend` project to improve functionality and update dependencies. The most important changes include updating the package version, adding new imports for time handling, and modifying the `logs` function to handle optional time parameters more robustly.

Version update:

* [`backend/Cargo.toml`](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L3-R3): Updated the package version from `0.4.23` to `0.4.24`.

Imports update:

* [`backend/src/http/machine.rs`](diffhunk://#diff-2fb7e351a99f5983a43c1653fcce6e763dfa61e72ec0a331681295875de921e8L9-R13): Added imports for `SystemTime` and `UNIX_EPOCH` to handle time calculations.

Functionality improvements:

* [`backend/src/http/machine.rs`](diffhunk://#diff-2fb7e351a99f5983a43c1653fcce6e763dfa61e72ec0a331681295875de921e8R510-R539): Modified the `logs` function to handle optional `from` and `to` parameters more robustly. If these parameters are not provided, it defaults to fetching logs from the last 24 hours.
[Copilot is generating a summary...]