### PR TITLE
delete logs older than 2 days for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,7 +2760,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "ivynet-backend"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "axum",
  "axum-extra",

--- a/backend/.sqlx/query-7ad4b0788274ce80a50eaf2b63d55aa5f9649a5fcd27b4364c41a4230a7d97c4.json
+++ b/backend/.sqlx/query-7ad4b0788274ce80a50eaf2b63d55aa5f9649a5fcd27b4364c41a4230a7d97c4.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM log WHERE created_at < $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamp"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7ad4b0788274ce80a50eaf2b63d55aa5f9649a5fcd27b4364c41a4230a7d97c4"
+}

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-backend"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -92,4 +92,7 @@ pub struct Config {
 
     #[arg(long)]
     pub update_node_data_versions: bool,
+
+    #[arg(long)]
+    pub delete_old_logs: bool,
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -39,6 +39,8 @@ async fn main() -> Result<(), BackendError> {
         update_node_data_versions(&pool, &Chain::Mainnet).await?;
         update_node_data_versions(&pool, &Chain::Holesky).await?;
         return Ok(());
+    } else if config.delete_old_logs {
+        Ok(db::log::ContainerLog::delete_old_logs(&pool).await?)
     } else {
         let cache = memcache::connect(config.cache_url.to_string())?;
         let http_service = http::serve(


### PR DESCRIPTION
This pull request introduces a feature to delete old logs from the database and includes several related changes. The most important changes are the addition of a new configuration option, a constant for the number of days to keep logs, and the implementation of the log deletion functionality.

### New Feature: Log Deletion

* [`backend/src/config.rs`](diffhunk://#diff-4946346ad049f4a14da173a6fd810a01a4f26f8653f27572738fa8bcd162b676R95-R97): Added a new configuration option `delete_old_logs` to enable or disable the log deletion feature.
* [`backend/src/db/log.rs`](diffhunk://#diff-797dfdaf02f56d611b59955909e50d4a0c41345b465d914011ecc9791ad0bdb9R10-R11): Introduced a constant `DAYS_TO_KEEP_LOGS` set to 2 days, and implemented the `delete_old_logs` method in the `ContainerLog` struct to delete logs older than the specified number of days. [[1]](diffhunk://#diff-797dfdaf02f56d611b59955909e50d4a0c41345b465d914011ecc9791ad0bdb9R10-R11) [[2]](diffhunk://#diff-797dfdaf02f56d611b59955909e50d4a0c41345b465d914011ecc9791ad0bdb9R286-R297)
* [`backend/src/main.rs`](diffhunk://#diff-03f0e815a03d93163cd4716a8ce1b5721eb199510b81334e5f5c1ae63af4704dR42-R43): Updated the main function to call the `delete_old_logs` method if the `delete_old_logs` configuration option is enabled.

### Supporting Changes

* [`backend/.sqlx/query-7ad4b0788274ce80a50eaf2b63d55aa5f9649a5fcd27b4364c41a4230a7d97c4.json`](diffhunk://#diff-30146a294a2058a47a4716930d79d1a8013642085f55230ca0ddc44a6419933aR1-R14): Added a new SQL query to delete logs older than a specified timestamp.
* [`backend/Cargo.toml`](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L3-R3): Incremented the version number from 0.4.26 to 0.4.27.