### PR TITLE
Bugfix for locally built containers

### DIFF
--- a/core/src/telemetry/metrics_listener.rs
+++ b/core/src/telemetry/metrics_listener.rs
@@ -218,6 +218,13 @@ pub async fn report_metrics(
             if let Some(image_name) = inspect_data.image() {
                 if let Some(hash) = images.get(image_name) {
                     version_hash = hash.clone();
+                } else if let Some(key) = images.keys().find(|key| key.contains(image_name)) {
+                    info!("Found hash from key.contains(image_name): {:#?}", key);
+                    if let Some(hash) = images.get(key) {
+                        version_hash = hash.clone();
+                    } else {
+                        error!("Failed to find hash for image: {}", image_name);
+                    }
                 }
             }
         }
@@ -243,7 +250,10 @@ pub async fn report_metrics(
 
         // Send node data
 
-        info!("Sending node data with version hash: {:#?}", version_hash);
+        info!(
+            "Sending node data with version hash: {:#?} for avs: {}",
+            version_hash, avs.assigned_name
+        );
 
         let node_data = NodeData {
             name: avs.assigned_name.to_owned(),

--- a/ivynet-docker/src/dockerapi.rs
+++ b/ivynet-docker/src/dockerapi.rs
@@ -206,6 +206,9 @@ impl DockerApi for DockerClient {
             if image.repo_digests.is_empty() {
                 debug!("No repo digests on image: {:#?}", image);
                 DockerClient::use_repo_tags(&image, &mut map);
+            } else if image.repo_tags.is_empty() && image.repo_digests.is_empty() {
+                debug!("No repo tags or digests on image: {:#?}", image);
+                map.insert("local".to_string(), image.id.clone());
             } else {
                 for digest in &image.repo_digests {
                     let elements = digest.split("@").collect::<Vec<_>>();


### PR DESCRIPTION
This pull request includes several changes to improve the handling of image hashes and logging in the telemetry metrics listener and Docker API implementation. The most important changes are grouped by theme and listed below.

### Improvements to image hash handling:

* [`core/src/telemetry/metrics_listener.rs`](diffhunk://#diff-188d4d144fabc9906bcbd78cb866708e6e662a87ed2fe5a9688c798250028930R221-R227): Added logic to find a hash using a partial match of the image name if an exact match is not found. This includes logging the key used for the partial match and handling the case where no hash is found.

### Enhancements to logging:

* [`core/src/telemetry/metrics_listener.rs`](diffhunk://#diff-188d4d144fabc9906bcbd78cb866708e6e662a87ed2fe5a9688c798250028930L246-R256): Enhanced the logging statement when sending node data to include the assigned name of the AVS.
* [`ivynet-docker/src/dockerapi.rs`](diffhunk://#diff-8fe1f74b50f17e021587c45bc3a75e539445949d725ace13e0f5f6795a806f9dR209-R211): Added a debug log statement for cases where both repo tags and digests are empty, and handled such cases by inserting the image ID with a "local" key.… map didn't work