### PR TITLE
remove perf score for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,7 +2760,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "ivynet-backend"
-version = "0.4.30"
+version = "0.4.31"
 dependencies = [
  "axum",
  "axum-extra",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-backend"
-version = "0.4.30"
+version = "0.4.31"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/backend/src/data/node_data.rs
+++ b/backend/src/data/node_data.rs
@@ -85,12 +85,6 @@ pub async fn build_avs_info(
         errors.push(NodeError::UnregisteredFromActiveSet);
     }
 
-    if let Some(perf) = metrics.get(EIGEN_PERFORMANCE_METRIC) {
-        if perf.value < EIGEN_PERFORMANCE_HEALTHY_THRESHOLD {
-            errors.push(NodeError::LowPerformanceScore);
-        }
-    }
-
     if let Some(datetime) = avs.updated_at {
         let now = chrono::Utc::now().naive_utc();
         if now.signed_duration_since(datetime).num_minutes() > IDLE_MINUTES_THRESHOLD {


### PR DESCRIPTION
This pull request includes several changes to the `ivynet-backend` project, focusing on version updates and code simplification. The most important changes are as follows:

Version update:
* [`backend/Cargo.toml`](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L3-R3): Updated the package version from "0.4.30" to "0.4.31".

Code simplification:
* [`backend/src/data/node_data.rs`](diffhunk://#diff-8985cb9b6580707f7a3da31d5fc480fe77bcdc15ad18577d0e4f714b26d2e6d5L88-L93): Removed the performance metric check for `EIGEN_PERFORMANCE_METRIC` and the associated error handling for low performance scores in the `build_avs_info` function.