### PR TITLE
remove perf score master

### DIFF
--- a/db/src/data/node_data.rs
+++ b/db/src/data/node_data.rs
@@ -84,12 +84,6 @@ pub async fn build_avs_info(
         errors.push(NodeError::UnregisteredFromActiveSet);
     }
 
-    if let Some(perf) = metrics.get(EIGEN_PERFORMANCE_METRIC) {
-        if perf.value < EIGEN_PERFORMANCE_HEALTHY_THRESHOLD {
-            errors.push(NodeError::LowPerformanceScore);
-        }
-    }
-
     if let Some(datetime) = avs.updated_at {
         let now = chrono::Utc::now().naive_utc();
         if now.signed_duration_since(datetime).num_minutes() > IDLE_MINUTES_THRESHOLD {


### PR DESCRIPTION
This pull request includes a change to the `build_avs_info` function in the `node_data.rs` file to remove the performance metric check.

Codebase simplification:

* [`db/src/data/node_data.rs`](diffhunk://#diff-775460fca1cd57c64976d0c1255f0094641fffac470cd15e0d55874d24e9a7d1L87-L92): Removed the check for `EIGEN_PERFORMANCE_METRIC` and its associated error handling in the `build_avs_info` function.