### PR TITLE
Release: altlayer no mainnet version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cli"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -2760,7 +2760,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "ivynet-backend"
-version = "0.4.31"
+version = "0.4.32"
 dependencies = [
  "axum",
  "axum-extra",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-backend"
-version = "0.4.31"
+version = "0.4.32"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/backend/src/data/avs_version.rs
+++ b/backend/src/data/avs_version.rs
@@ -100,7 +100,7 @@ pub async fn find_latest_avs_version(
 
             // If a version type is semver, we sanitize the list, discarding the other
             // elements.
-            let version_vec = version_list
+            let mut version_vec = version_list
                 .iter()
                 .filter_map(|version_data| {
                     let raw_tag = version_data.version.clone();
@@ -111,9 +111,13 @@ pub async fn find_latest_avs_version(
                 })
                 .collect::<Vec<_>>();
 
-            // filter prerelease versions
-            let version_vec =
-                version_vec.into_iter().filter(|(v, _, _)| v.pre.is_empty()).collect::<Vec<_>>();
+            if *chain == Chain::Mainnet {
+                // filter prerelease versions
+                version_vec = version_vec
+                    .into_iter()
+                    .filter(|(v, _, _)| v.pre.is_empty())
+                    .collect::<Vec<_>>();
+            }
 
             let latest = version_vec
                 .iter()

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -36,6 +36,8 @@ async fn main() -> Result<(), BackendError> {
     } else if config.add_node_version_hashes {
         Ok(add_node_version_hashes(&pool).await?)
     } else if config.update_node_data_versions {
+        let node_types = NodeType::all_known_with_repo();
+        db::DbAvsVersionData::delete_avses_from_avs_version_data(&pool, &node_types).await?;
         update_node_data_versions(&pool, &Chain::Mainnet).await?;
         update_node_data_versions(&pool, &Chain::Holesky).await?;
         return Ok(());
@@ -199,9 +201,7 @@ async fn add_node_version_hashes(pool: &PgPool) -> Result<(), BackendError> {
 
 async fn update_node_data_versions(pool: &PgPool, chain: &Chain) -> Result<(), BackendError> {
     info!("Updating node data versions for {:?}", chain);
-    let node_types = NodeType::all_known_with_repo();
-    db::DbAvsVersionData::delete_avses_from_avs_version_data(pool, &node_types).await?;
-    for node_type in node_types {
+    for node_type in NodeType::all_known_with_repo() {
         match (node_type, chain) {
             (NodeType::Gasp, _) => continue,
             (NodeType::K3LabsAvsHolesky, Chain::Mainnet) => continue,


### PR DESCRIPTION
This pull request includes several changes to the `ivynet-backend` project, focusing on version updates, code improvements, and bug fixes. The most important changes include updating the package version, modifying the `find_latest_avs_version` function to handle prerelease versions conditionally, and refactoring the `update_node_data_versions` function.

Version updates:

* [`backend/Cargo.toml`](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L3-R3): Updated the package version from `0.4.31` to `0.4.32`.

Code improvements:

* [`backend/src/data/avs_version.rs`](diffhunk://#diff-20336981be9b261df2cfb42de4f5880e342c274549759b273918bffc790412a8L103-R103): Modified the `find_latest_avs_version` function to use a mutable version vector and added a conditional filter for prerelease versions when the chain is `Mainnet`. [[1]](diffhunk://#diff-20336981be9b261df2cfb42de4f5880e342c274549759b273918bffc790412a8L103-R103) [[2]](diffhunk://#diff-20336981be9b261df2cfb42de4f5880e342c274549759b273918bffc790412a8R114-R120)

Bug fixes and refactoring:

* [`backend/src/main.rs`](diffhunk://#diff-03f0e815a03d93163cd4716a8ce1b5721eb199510b81334e5f5c1ae63af4704dR39-R40): Added a call to `DbAvsVersionData::delete_avses_from_avs_version_data` before updating node data versions in the `main` function.
* [`backend/src/main.rs`](diffhunk://#diff-03f0e815a03d93163cd4716a8ce1b5721eb199510b81334e5f5c1ae63af4704dL202-R204): Refactored the `update_node_data_versions` function to remove redundant calls and streamline the process.
[Copilot is generating a summary...]