### PR TITLE
scraper versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4677,7 +4677,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/scraper/Cargo.toml
+++ b/scraper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scraper"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 repository.workspace = true
 categories.workspace = true

--- a/scraper/build.rs
+++ b/scraper/build.rs
@@ -1,0 +1,19 @@
+use std::{env, fs::File, io::Write as _, path::PathBuf, process::Command};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let version_file_path = out.join("version.rs");
+
+    let output =
+        Command::new("git").args(vec!["log", "-n 1", r#"--pretty=format:"%H""#]).output()?;
+    let hash = std::str::from_utf8(&output.stdout)?.replace("\"", "");
+
+    let mut version_file = File::create(version_file_path)?;
+
+    let version_hash = format!("{} ({hash})", env!("CARGO_PKG_VERSION"));
+    version_file
+        .write_all(format!(r#"pub const VERSION_HASH: &str = "{version_hash}";"#).as_bytes())?;
+
+    version_file.sync_all()?;
+    Ok(())
+}

--- a/scraper/src/main.rs
+++ b/scraper/src/main.rs
@@ -10,7 +10,12 @@ use scraper::blockchain;
 use tracing::{info, level_filters::LevelFilter};
 use tracing_subscriber::FmtSubscriber;
 
-#[derive(Clone, Parser)]
+mod version_hash {
+    include!(concat!(env!("OUT_DIR"), "/version.rs"));
+}
+
+#[derive(Clone, Parser, Debug)]
+#[command(name = "scraper", version = version_hash::VERSION_HASH, about = "Ivynet scraper service")]
 pub struct Params {
     #[arg(long, env = "BACKEND_URL", value_parser = Uri::from_str, default_value = if cfg!(debug_assertions) {
         "http://localhost:50051"


### PR DESCRIPTION
This pull request includes several changes to the `scraper` project, focusing on versioning and including the latest Git commit hash in the build output. The most important changes include updating the package version, adding a build script to generate a version file, and modifying the main application to use this version information.

Versioning and build improvements:

* [`scraper/Cargo.toml`](diffhunk://#diff-a87e294b9c718b464377f2cdb6b34629d8604b5d599e743243ebafe30f2f5615L3-R3): Updated the package version from `0.4.2` to `0.4.3`.
* [`scraper/build.rs`](diffhunk://#diff-1a3e79379f4aba7d5efd3e5db87979478bb5478cf9c0d5dafa54ab66b36f3032R1-R19): Added a new build script to generate a `version.rs` file containing the package version and the latest Git commit hash.

Main application changes:

* [`scraper/src/main.rs`](diffhunk://#diff-c567aab5cbf3d2fbc3535e49edf2ba980adf22979542d6067b18c304b75d529eL13-R18): Included the generated `version.rs` file and used the `VERSION_HASH` constant to set the version information in the `Params` struct.