### PR TITLE
master scraper version

### DIFF
--- a/scraper/build.rs
+++ b/scraper/build.rs
@@ -1,0 +1,19 @@
+use std::{env, fs::File, io::Write as _, path::PathBuf, process::Command};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let version_file_path = out.join("version.rs");
+
+    let output =
+        Command::new("git").args(vec!["log", "-n 1", r#"--pretty=format:"%H""#]).output()?;
+    let hash = std::str::from_utf8(&output.stdout)?.replace("\"", "");
+
+    let mut version_file = File::create(version_file_path)?;
+
+    let version_hash = format!("{} ({hash})", env!("CARGO_PKG_VERSION"));
+    version_file
+        .write_all(format!(r#"pub const VERSION_HASH: &str = "{version_hash}";"#).as_bytes())?;
+
+    version_file.sync_all()?;
+    Ok(())
+}

--- a/scraper/src/main.rs
+++ b/scraper/src/main.rs
@@ -10,7 +10,12 @@ use scraper::blockchain;
 use tracing::{info, level_filters::LevelFilter};
 use tracing_subscriber::FmtSubscriber;
 
-#[derive(Clone, Parser)]
+mod version_hash {
+    include!(concat!(env!("OUT_DIR"), "/version.rs"));
+}
+
+#[derive(Clone, Parser, Debug)]
+#[command(name = "scraper", version = version_hash::VERSION_HASH, about = "Ivynet scraper service")]
 pub struct Params {
     #[arg(long, env = "BACKEND_URL", value_parser = Uri::from_str, default_value = if cfg!(debug_assertions) {
         "http://localhost:50051"


### PR DESCRIPTION
This pull request introduces a new feature to include the current Git commit hash in the version information of the `scraper` project. The main changes involve generating a `version.rs` file during the build process and including this version information in the command-line interface (CLI) of the scraper service.

### Feature addition:

* [`scraper/build.rs`](diffhunk://#diff-1a3e79379f4aba7d5efd3e5db87979478bb5478cf9c0d5dafa54ab66b36f3032R1-R19): Added a build script to generate a `version.rs` file containing the current Git commit hash and the package version. This script creates the file in the output directory specified by the `OUT_DIR` environment variable.

### CLI update:

* [`scraper/src/main.rs`](diffhunk://#diff-c567aab5cbf3d2fbc3535e49edf2ba980adf22979542d6067b18c304b75d529eL13-R18): Modified the `Params` struct to include the version information from the generated `version.rs` file in the CLI output. This ensures that the version displayed includes the current Git commit hash.