### PR TITLE
First iteration of image merge scanner implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "ivynet-docker",
  "ivynet-grpc",
  "ivynet-io",
+ "ivynet-node-type",
  "ivynet-signer",
  "linemux",
  "once_cell",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ ivynet-docker.workspace = true
 ivynet-grpc.workspace = true
 ivynet-io.workspace = true
 ivynet-signer.workspace = true
-
+ivynet-node-type.workspace = true
 bollard.workspace = true
 clap = { version = "4.5.7", features = ["derive", "env"] }
 dirs.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -57,13 +57,20 @@ enum Commands {
         subcmd: key::KeyCommands,
     },
     #[command(name = "monitor", about = "Start node monitor daemon")]
-    Monitor,
+    Monitor {
+        /// To keep containers split even if they are using the same image
+        #[arg(short, long, default_value_t = false)]
+        no_merge: bool,
+    },
 
     #[command(name = "scan", about = "Scanning for existing AVS instances running on the machine")]
     Scan {
         /// For forcing manual container addition even when all other AVS's are already configured
         #[arg(short, long, default_value_t = false)]
         force: bool,
+        /// To keep containers split even if they are using the same image
+        #[arg(short, long, default_value_t = false)]
+        no_merge: bool,
     },
 
     #[command(
@@ -113,8 +120,8 @@ async fn main() -> Result<(), AnyError> {
         }
         Commands::Key { subcmd } => key::parse_key_subcommands(subcmd).await?,
         // Commands::Node { subcmd } => avs::parse_avs_subcommands(subcmd).await?,
-        Commands::Monitor => monitor::start_monitor(config).await?,
-        Commands::Scan { force } => monitor::scan(force, &config).await?,
+        Commands::Monitor { no_merge } => monitor::start_monitor(!no_merge, config).await?,
+        Commands::Scan { force, no_merge } => monitor::scan(force, no_merge, &config).await?,
         Commands::RegisterNode => init::register_node().await?,
         Commands::RenameNode { old_name, new_name } => {
             monitor::rename_node(&config, old_name, new_name).await?;

--- a/cli/src/monitor.rs
+++ b/cli/src/monitor.rs
@@ -77,6 +77,19 @@ impl MonitorConfig {
         });
         self.store()
     }
+
+    pub fn change_avs_container_name(
+        &mut self,
+        old_name: &str,
+        new_name: &str,
+    ) -> Result<(), MonitorConfigError> {
+        self.configured_avses.iter_mut().for_each(|avs| {
+            if avs.container_name == old_name {
+                avs.container_name = new_name.to_string();
+            }
+        });
+        self.store()
+    }
 }
 
 pub async fn rename_node(

--- a/cli/src/monitor.rs
+++ b/cli/src/monitor.rs
@@ -125,6 +125,25 @@ impl MonitorConfig {
         }
     }
 
+    pub fn activate_avs(
+        &mut self,
+        name: &str,
+        avs_type: Option<NodeType>,
+    ) -> Option<ConfiguredAvs> {
+        if let Some(avs) = self.configured_avses.iter_mut().find(|avs| {
+            if let Some(node_type) = avs_type {
+                avs.container_name == name || NodeType::from(avs.avs_type.as_str()) == node_type
+            } else {
+                avs.container_name == name
+            }
+        }) {
+            avs.active = true;
+            Some(avs.clone())
+        } else {
+            None
+        }
+    }
+
     pub fn change_active_state(
         &mut self,
         avs_name: &str,

--- a/cli/src/telemetry/docker_event_stream_listener.rs
+++ b/cli/src/telemetry/docker_event_stream_listener.rs
@@ -11,7 +11,7 @@ use ivynet_node_type::NodeType;
 use ivynet_signer::{sign_utils::sign_node_data, IvyWallet};
 use tokio::time::sleep;
 use tokio_stream::StreamExt;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 use uuid::Uuid;
 
 use super::{

--- a/cli/src/telemetry/docker_event_stream_listener.rs
+++ b/cli/src/telemetry/docker_event_stream_listener.rs
@@ -108,6 +108,7 @@ impl DockerStreamListener<DockerClient> {
             }
         };
 
+        // TODO: This query to backend seems to be extremely slow. Need to investigate
         let guessed_type: Option<NodeType> = if !self.merging_containers {
             self.backend
                 .node_type_queries(Request::new(NodeTypeQueries {

--- a/cli/src/telemetry/docker_event_stream_listener.rs
+++ b/cli/src/telemetry/docker_event_stream_listener.rs
@@ -163,6 +163,7 @@ impl DockerStreamListener<DockerClient> {
                     image_name: Some(inc_image_name.clone()),
                     avs_type: found_type,
                     metric_port: metrics_port,
+                    active: true,
                 })
             }
         };

--- a/cli/src/telemetry/docker_event_stream_listener.rs
+++ b/cli/src/telemetry/docker_event_stream_listener.rs
@@ -129,6 +129,7 @@ impl DockerStreamListener<DockerClient> {
         } else {
             None
         };
+
         // We treat an avs with the same image as the same avs configuration, so whenever an avs is
         // found using the same image, we are updating the configured avs that is already on the
         // list

--- a/cli/src/telemetry/docker_event_stream_listener.rs
+++ b/cli/src/telemetry/docker_event_stream_listener.rs
@@ -84,7 +84,6 @@ impl DockerStreamListener<DockerClient> {
         event: EventMessage,
         avses: &[ConfiguredAvs],
     ) -> Result<(), DockerStreamListenerError> {
-        info!("Starting new docker");
         let actor = event.actor.ok_or(DockerStreamError::MissingActor)?;
         let attributes = actor.attributes.ok_or(DockerStreamError::MissingAttributes)?;
         let inc_container_name =

--- a/cli/src/telemetry/metrics_listener.rs
+++ b/cli/src/telemetry/metrics_listener.rs
@@ -175,8 +175,8 @@ impl<D: DockerApi> MetricsListener<D> {
         .await?
         {
             Some((avs_to_replace, Some(replacement))) => {
-                // TODO: This is a hack .This should be somehow marked in the loop process, but I don't
-                // have an access to sender of the channel.
+                // TODO: This is a hack .This should be somehow marked in the loop process, but I
+                // don't have an access to sender of the channel.
                 // I'm open for suggestions how to handle it
                 self.avs_cache.remove(&avs_to_replace);
                 self.avses.retain(|x| x.container_name != avs_to_replace.container_name);
@@ -191,8 +191,8 @@ impl<D: DockerApi> MetricsListener<D> {
                         &replacement.container_name,
                     );
                 }
-                // We do nothning else here. In next round of the loop this will rename will be used in
-                // the metrics queue
+                // We do nothning else here. In next round of the loop this will rename will be used
+                // in the metrics queue
             }
             Some((avs_to_remove, None)) => {
                 self.avs_cache.remove(&avs_to_remove);
@@ -226,10 +226,17 @@ impl<D: DockerApi> MetricsListener<D> {
                     }
                     // We need to resave the monitor file
                     if let Ok(mut monitor_config) = MonitorConfig::load_from_default_path() {
-                        monitor_config.configured_avses.push(avs.clone());
-                        _ = monitor_config.store();
-                    } else {
-                        error!("Cannot load monitor config for changes");
+                        if monitor_config
+                            .configured_avses
+                            .iter()
+                            .find(|x| x.container_name == avs.container_name)
+                            .is_none()
+                        {
+                            monitor_config.configured_avses.push(avs.clone());
+                            _ = monitor_config.store();
+                        } else {
+                            error!("Cannot load monitor config for changes");
+                        }
                     }
                 }
             }

--- a/cli/src/telemetry/metrics_listener.rs
+++ b/cli/src/telemetry/metrics_listener.rs
@@ -235,7 +235,10 @@ pub async fn report_metrics(
     debug!("System Docker images: {:#?}", images);
 
     for avs in avses {
-        let version_hash = match docker.find_container_by_name(&avs.container_name).await {
+        let version_hash = match docker
+            .find_container_by_name_or_image(&avs.container_name, &avs.image_name)
+            .await
+        {
             None => {
                 warn!(
                     "Container {} is configured but does not appear to be running. Skipping telemetry.",

--- a/cli/src/telemetry/metrics_listener.rs
+++ b/cli/src/telemetry/metrics_listener.rs
@@ -170,6 +170,8 @@ impl<D: DockerApi> MetricsListener<D> {
             if let Err(e) = res {
                 let _ = self.error_tx.send(e.into());
             }
+
+            _ = self.config.lock().await.store();
         }
     }
 

--- a/cli/src/telemetry/metrics_listener.rs
+++ b/cli/src/telemetry/metrics_listener.rs
@@ -183,34 +183,6 @@ impl<D: DockerApi> MetricsListener<D> {
             &mut self.avs_cache,
         )
         .await
-        // {
-        //     Some((avs_to_replace, Some(replacement))) => {
-        //         // TODO: This is a hack .This should be somehow marked in the loop process, but I
-        //         // don't have an access to sender of the channel.
-        //         // I'm open for suggestions how to handle it
-        //         self.avs_cache.remove(&avs_to_replace);
-        //         self.avses.retain(|x| x.container_name != avs_to_replace.container_name);
-        //         self.avs_cache.insert(
-        //             replacement.clone(),
-        //             (Some(replacement.avs_type.to_string()), "".to_string(), false),
-        //         );
-        //         self.avses.push(replacement.clone());
-        //         if let Ok(mut config) = MonitorConfig::load_from_default_path() {
-        //             _ = config.change_avs_container_name(
-        //                 &avs_to_replace.container_name,
-        //                 &replacement.container_name,
-        //             );
-        //         }
-        //         // We do nothning else here. In next round of the loop this will rename will be
-        // used         // in the metrics queue
-        //     }
-        //     Some((avs_to_remove, None)) => {
-        //         self.avs_cache.remove(&avs_to_remove);
-        //         self.avses.retain(|x| x.container_name != avs_to_remove.container_name);
-        //     }
-        //     _ => {}
-        // }
-        // Ok(())
     }
 
     async fn handle_action(

--- a/cli/src/telemetry/metrics_listener.rs
+++ b/cli/src/telemetry/metrics_listener.rs
@@ -234,9 +234,9 @@ impl<D: DockerApi> MetricsListener<D> {
                         {
                             monitor_config.configured_avses.push(avs.clone());
                             _ = monitor_config.store();
-                        } else {
-                            error!("Cannot load monitor config for changes");
                         }
+                    } else {
+                        error!("Cannot load monitor config for changes");
                     }
                 }
             }

--- a/cli/src/telemetry/mod.rs
+++ b/cli/src/telemetry/mod.rs
@@ -172,7 +172,7 @@ pub async fn listen(
         &docker,
         machine_id,
         &identity_wallet,
-        config,
+        config.clone(),
         &dispatch,
         error_tx,
     );
@@ -188,7 +188,7 @@ pub async fn listen(
         backend_client,
         merge_containers,
     );
-    tokio::spawn(docker_listener.run(active_avses));
+    tokio::spawn(docker_listener.run(config));
 
     // This should never return unless the error channel is closed
     handle_telemetry_errors(error_rx).await?;

--- a/cli/src/telemetry/mod.rs
+++ b/cli/src/telemetry/mod.rs
@@ -43,6 +43,7 @@ pub enum TelemetryError {
 pub struct ConfiguredAvs {
     pub assigned_name: String,
     pub container_name: String,
+    pub image_name: Option<String>,
     pub avs_type: String,
     pub metric_port: Option<u16>,
 }
@@ -63,6 +64,7 @@ impl<'de> Deserialize<'de> for ConfiguredAvs {
         struct Helper {
             assigned_name: String,
             container_name: String,
+            image_name: Option<String>,
             #[serde(default)]
             metric_port: Option<u16>,
             avs_type: AvsTypeField,
@@ -91,6 +93,7 @@ impl<'de> Deserialize<'de> for ConfiguredAvs {
         Ok(ConfiguredAvs {
             assigned_name: helper.assigned_name,
             container_name: helper.container_name,
+            image_name: helper.image_name,
             avs_type,
             metric_port: helper.metric_port,
         })
@@ -135,6 +138,7 @@ pub async fn listen(
     machine_id: Uuid,
     identity_wallet: IvyWallet,
     avses: &[ConfiguredAvs],
+    merge_containers: bool,
 ) -> Result<(), Error> {
     let docker = DockerClient::default();
 
@@ -178,6 +182,7 @@ pub async fn listen(
         identity_wallet,
         machine_id,
         backend_client,
+        merge_containers,
     );
     tokio::spawn(docker_listener.run(avses.to_vec()));
 

--- a/ivynet-docker/src/dockerapi.rs
+++ b/ivynet-docker/src/dockerapi.rs
@@ -119,6 +119,25 @@ pub trait DockerApi: Clone + Sync + Send + 'static {
             .collect()
     }
 
+    async fn find_container_by_name_or_image(
+        &self,
+        name: &str,
+        image: &Option<String>,
+    ) -> Option<Container> {
+        let containers = self.list_containers().await;
+        containers
+            .into_iter()
+            .find(|container| {
+                container
+                    .names
+                    .as_ref()
+                    .map(|names| names.iter().any(|n| n.contains(name)))
+                    .unwrap_or_default()
+                    || container.image.as_ref() == image.as_ref()
+            })
+            .map(Container::new)
+    }
+
     async fn stream_logs_latest(
         &self,
         container: Container,

--- a/ivynet-docker/src/dockerapi.rs
+++ b/ivynet-docker/src/dockerapi.rs
@@ -132,8 +132,8 @@ pub trait DockerApi: Clone + Sync + Send + 'static {
                     .names
                     .as_ref()
                     .map(|names| names.iter().any(|n| n.contains(name)))
-                    .unwrap_or_default()
-                    || container.image.as_ref() == image.as_ref()
+                    .unwrap_or_default() ||
+                    container.image.as_ref() == image.as_ref()
             })
             .map(Container::new)
     }

--- a/ivynet-docker/src/dockerapi.rs
+++ b/ivynet-docker/src/dockerapi.rs
@@ -119,22 +119,11 @@ pub trait DockerApi: Clone + Sync + Send + 'static {
             .collect()
     }
 
-    async fn find_container_by_name_or_image(
-        &self,
-        name: &str,
-        image: &Option<String>,
-    ) -> Option<Container> {
+    async fn find_container_by_image(&self, image: &Option<String>) -> Option<Container> {
         let containers = self.list_containers().await;
         containers
             .into_iter()
-            .find(|container| {
-                container
-                    .names
-                    .as_ref()
-                    .map(|names| names.iter().any(|n| n.contains(name)))
-                    .unwrap_or_default() ||
-                    container.image.as_ref() == image.as_ref()
-            })
+            .find(|container| container.image.as_ref() == image.as_ref())
             .map(Container::new)
     }
 


### PR DESCRIPTION
- While scanning, the scanner tries to match any potential AVSes with already configured ones by the image it is using
- At the same time, `DockerStreamListener` updates configured AVSes structure whenever starting container (`on_start` event) is also a container using the same image as already configured AVS, merging them together

NOTE:
- For the procedure to work properly, an admin need to run `ivynet scan` to update configuration with image data