### PR TITLE
Feat/symbiotic avs

### DIFF
--- a/core/src/directory.rs
+++ b/core/src/directory.rs
@@ -17,7 +17,7 @@ const ALL_MAINNET_AVSES: [(NodeType, H160); 29] = [
     (NodeType::LagrangeZkWorker, h160!(0x22CAc0e6A1465F043428e8AeF737b3cb09D0eEDa)),
     (NodeType::LagrangeStateCommittee, h160!(0x35F4f28A8d3Ff20EEd10e087e8F96Ea2641E6AA2)),
     (NodeType::EOracle, h160!(0x23221c5bB90C7c57ecc1E75513e2E4257673F0ef)),
-    (NodeType::Hyperlane, h160!(0xe8E59c6C8B56F2c178f63BCFC4ce5e5e2359c8fc)),
+    (NodeType::Hyperlane(ActiveSet::Eigenlayer), h160!(0xe8E59c6C8B56F2c178f63BCFC4ce5e5e2359c8fc)),
     (NodeType::K3LabsAvs, h160!(0x83742C346E9f305dcA94e20915aB49A483d33f3E)),
     (NodeType::WitnessChain, h160!(0xD25c2c5802198CB8541987b73A8db4c9BCaE5cC7)),
     (NodeType::AvaProtocol, h160!(0x18343Aa10e3D2F3A861e5649627324aEAD987Adf)),
@@ -71,7 +71,7 @@ const ALL_HOLESKY_AVSES: [(NodeType, H160); 34] = [
     (NodeType::LagrangeStateCommittee, h160!(0x18A74E66cc90F0B1744Da27E72Df338cEa0A542b)),
     (NodeType::LagrangeZkWorker, h160!(0xf98d5de1014110c65c51b85ea55f73863215cc10)),
     (NodeType::EOracle, h160!(0x80FE337623Bc849F4b7379f4AB28aF2b470bEa98)),
-    (NodeType::Hyperlane, h160!(0xc76E477437065093D353b7d56c81ff54D167B0Ab)),
+    (NodeType::Hyperlane(ActiveSet::Eigenlayer), h160!(0xc76E477437065093D353b7d56c81ff54D167B0Ab)),
     // K3 doesn't seem to have a testnet
     (NodeType::WitnessChain, h160!(0xa987EC494b13b21A8a124F8Ac03c9F530648C87D)),
     (NodeType::AvaProtocol, h160!(0xEA3E82F9Ae371A6a372A6DCffB1a9bD17e0608eF)),

--- a/db/src/data/avs_version.rs
+++ b/db/src/data/avs_version.rs
@@ -19,6 +19,7 @@ pub enum VersionType {
 impl From<&NodeType> for VersionType {
     fn from(node_type: &NodeType) -> Self {
         match node_type {
+            NodeType::Tanssi => VersionType::FixedVer,
             NodeType::Bolt(_) => VersionType::SemVer,
             NodeType::Zellular => VersionType::FixedVer,
             NodeType::AtlasNetwork => VersionType::FixedVer,
@@ -33,7 +34,7 @@ impl From<&NodeType> for VersionType {
             NodeType::K3LabsAvs => VersionType::FixedVer,
             NodeType::K3LabsAvsHolesky => VersionType::FixedVer,
             NodeType::Predicate => VersionType::SemVer,
-            NodeType::Hyperlane => VersionType::SemVer,
+            NodeType::Hyperlane(_) => VersionType::SemVer,
             NodeType::WitnessChain => VersionType::SemVer,
             NodeType::Unknown => VersionType::SemVer,
             NodeType::LagrangeStateCommittee => VersionType::SemVer,
@@ -58,6 +59,7 @@ impl From<&NodeType> for VersionType {
             NodeType::Blockless => VersionType::LocalOnly,
             NodeType::Redstone => VersionType::LocalOnly,
             NodeType::MishtiNetwork => VersionType::LocalOnly,
+            NodeType::Cycle => VersionType::LocalOnly,
         }
     }
 }
@@ -78,6 +80,7 @@ impl VersionType {
             (NodeType::ArpaNetworkNodeClient, _) => Some("latest"),
             (NodeType::AtlasNetwork, _) => Some("testnet-eigenlayer"),
             (NodeType::Zellular, _) => Some("latest"),
+            (NodeType::Tanssi, _) => Some("latest"),
             _ => None,
         }
     }

--- a/ivynet-docker-registry/src/registry.rs
+++ b/ivynet-docker-registry/src/registry.rs
@@ -14,6 +14,7 @@ pub trait ImageRegistry {
 impl ImageRegistry for NodeType {
     fn registry(&self) -> Result<RegistryType, NodeTypeError> {
         let res = match self {
+            Self::Tanssi => DockerHub,
             Self::Redstone => Othentic,
             Self::Bolt(_) => Github,
             Self::Zellular => DockerHub,
@@ -30,7 +31,7 @@ impl ImageRegistry for NodeType {
             Self::K3LabsAvs => DockerHub,
             Self::K3LabsAvsHolesky => DockerHub,
             Self::Predicate => Github,
-            Self::Hyperlane => GoogleCloud,
+            Self::Hyperlane(_) => GoogleCloud,
             Self::WitnessChain => DockerHub,
             Self::Altlayer(_altlayer_type) => AWS,
             Self::AltlayerMach(_altlayer_mach_type) => AWS,
@@ -51,6 +52,7 @@ impl ImageRegistry for NodeType {
             Self::AlignedLayer => Local,
             Self::PrimevMevCommit(_) => Local,
             Self::Blockless => Local,
+            Self::Cycle => Local,
             Self::UnifiAVS => return Err(NodeTypeError::InvalidNodeType),
             Self::Unknown => return Err(NodeTypeError::InvalidNodeType),
         };
@@ -170,6 +172,8 @@ pub enum DockerRegistryError {
 #[cfg(test)]
 mod docker_registry_tests {
 
+    use ivynet_node_type::ActiveSet;
+
     use super::*;
 
     #[test]
@@ -274,7 +278,7 @@ mod docker_registry_tests {
 
     #[tokio::test]
     async fn test_get_hyperlane_digests() -> Result<(), Box<dyn std::error::Error>> {
-        let node_type = NodeType::Hyperlane;
+        let node_type = NodeType::Hyperlane(ActiveSet::Unknown);
         let client = DockerRegistry::from_node_type(&node_type).await?;
         let tags = client.get_tags().await?;
         assert!(!tags.is_empty());

--- a/ivynet-node-type/src/restaking_protocol.rs
+++ b/ivynet-node-type/src/restaking_protocol.rs
@@ -24,7 +24,6 @@ impl RestakingProtocol for NodeType {
             NodeType::EOracle => RestakingProtocolType::Eigenlayer,
             NodeType::Gasp => RestakingProtocolType::Eigenlayer,
             NodeType::Predicate => RestakingProtocolType::Eigenlayer,
-            NodeType::Hyperlane => RestakingProtocolType::Eigenlayer,
             NodeType::WitnessChain => RestakingProtocolType::Eigenlayer,
             NodeType::Omni => RestakingProtocolType::Eigenlayer,
             NodeType::Automata => RestakingProtocolType::Eigenlayer,
@@ -47,7 +46,8 @@ impl RestakingProtocol for NodeType {
             NodeType::Redstone => RestakingProtocolType::Eigenlayer,
             NodeType::MishtiNetwork => RestakingProtocolType::Eigenlayer,
             //Symbiotic
-
+            NodeType::Cycle => RestakingProtocolType::Symbiotic,
+            NodeType::Tanssi => RestakingProtocolType::Symbiotic,
             //Complicated
             NodeType::Altlayer(inner) => match inner {
                 AltlayerType::Unknown => return None,
@@ -73,6 +73,11 @@ impl RestakingProtocol for NodeType {
                 ActiveSet::Symbiotic => RestakingProtocolType::Symbiotic,
             },
             NodeType::Bolt(inner) => match inner {
+                ActiveSet::Unknown => return None,
+                ActiveSet::Eigenlayer => RestakingProtocolType::Eigenlayer,
+                ActiveSet::Symbiotic => RestakingProtocolType::Symbiotic,
+            },
+            NodeType::Hyperlane(inner) => match inner {
                 ActiveSet::Unknown => return None,
                 ActiveSet::Eigenlayer => RestakingProtocolType::Eigenlayer,
                 ActiveSet::Symbiotic => RestakingProtocolType::Symbiotic,


### PR DESCRIPTION
This pull request introduces several changes to the `ivynet` project, focusing on enhancing the `NodeType` enum by adding the `ActiveSet` enum and updating various parts of the codebase to accommodate these changes. The most important changes include updates to the `NodeType` enum, adjustments to the serialization and deserialization logic, and modifications to how `NodeType` is used in different contexts.

### Enhancements to `NodeType` Enum:

* [`ivynet-node-type/src/lib.rs`](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3L50-R71): Added `ActiveSet` enum and updated `NodeType` to include variants with `ActiveSet`. This includes new variants such as `Hyperlane(ActiveSet)`, `PrimevMevCommit(ActiveSet)`, and `Bolt(ActiveSet)`. [[1]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3L50-R71) [[2]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3L69-R94)

### Serialization and Deserialization Updates:

* [`ivynet-node-type/src/lib.rs`](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3L161-R221): Updated the `Serialize` implementation for `NodeType` to handle new compound types with `ActiveSet`. Introduced a helper function `serialize_compound` to streamline the serialization process.

### Code Adjustments for New `NodeType` Variants:

* [`core/src/directory.rs`](diffhunk://#diff-bef971be0e73c6412e1012f9fb52311c61ca6080a05b5e6dba9bb10edb9968e8L18-R20): Updated various constants to use the new `NodeType` variants with `ActiveSet`. For example, `NodeType::Hyperlane` was changed to `NodeType::Hyperlane(ActiveSet::Eigenlayer)`. [[1]](diffhunk://#diff-bef971be0e73c6412e1012f9fb52311c61ca6080a05b5e6dba9bb10edb9968e8L18-R20) [[2]](diffhunk://#diff-bef971be0e73c6412e1012f9fb52311c61ca6080a05b5e6dba9bb10edb9968e8L59-R64)
* [`db/src/data/avs_version.rs`](diffhunk://#diff-ed1951db49cc0ee01924c8e73980c255dc0a20f0ac45f53ca0c52b82fde314caL36-R62): Modified the `VersionType` conversion to handle the new `NodeType` variants with `ActiveSet`. For instance, `NodeType::Hyperlane` is now `NodeType::Hyperlane(_)`.
* [`ivynet-docker-registry/src/registry.rs`](diffhunk://#diff-d2c6da20847f07c5bc471399422b9654c679b7ef726f8b6984482539ab019486L33-R34): Updated the `ImageRegistry` trait implementation to handle the new `NodeType` variants with `ActiveSet`. [[1]](diffhunk://#diff-d2c6da20847f07c5bc471399422b9654c679b7ef726f8b6984482539ab019486L33-R34) [[2]](diffhunk://#diff-d2c6da20847f07c5bc471399422b9654c679b7ef726f8b6984482539ab019486L52-R55)

### Additional Changes:

* [`ivynet-node-type/src/lib.rs`](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R6-R50): Added a new module `restaking_protocol` and updated the `NodeType` enum to include `Tanssi` and `Cycle`. [[1]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R6-R50) [[2]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3L69-R94)
* [`ivynet-docker-registry/src/registry.rs`](diffhunk://#diff-d2c6da20847f07c5bc471399422b9654c679b7ef726f8b6984482539ab019486L277-R281): Added test cases to handle the new `NodeType` variants with `ActiveSet`.

These changes collectively enhance the flexibility and functionality of the `NodeType` enum, allowing it to represent more complex states and improving the overall robustness of the codebase.