### PR TITLE
Ditto problem fix

### DIFF
--- a/cli/src/telemetry/docker_event_stream_listener.rs
+++ b/cli/src/telemetry/docker_event_stream_listener.rs
@@ -108,7 +108,9 @@ impl<B: BackendMiddleware> DockerStreamListener<DockerClient, B> {
                     info!("Broadcasting telemetry on tick...");
 
                     let signed_machine_data = self.machine.sign_machine_data()?;
-                    self.machine_data_monitor_handle.tell_send_machine_data(signed_machine_data).await;
+                    if let Err(e) = self.machine_data_monitor_handle.ask_send_machine_data(signed_machine_data).await {
+                        error!("Failed to send machine data: {}", e);
+                    }
 
                     for node in known_nodes.iter() {
                         let manifest = node.manifest.clone().unwrap_or(ContainerId("".to_string()));

--- a/db/src/avs.rs
+++ b/db/src/avs.rs
@@ -262,9 +262,6 @@ impl Avs {
         avs_name: &str,
         node_type: &NodeType,
     ) -> Result<(), DatabaseError> {
-        println!("NODE TYPE: {:#?}", node_type);
-        println!("MACHINE ID: {:#?}", machine_id);
-        println!("AVS NAME: {:#?}", avs_name);
         let result = sqlx::query!(
             "UPDATE avs SET avs_type = $1 WHERE machine_id = $2 AND avs_name = $3",
             node_type.to_string(),
@@ -273,7 +270,6 @@ impl Avs {
         )
         .execute(pool)
         .await?;
-        println!("RESULT: {:#?}", result);
 
         Ok(())
     }

--- a/ivynet-node-type/src/lib.rs
+++ b/ivynet-node-type/src/lib.rs
@@ -238,8 +238,10 @@ impl Serialize for NodeType {
             }
             NodeType::Bolt(inner) => serialize_compound("bolt", inner, serializer),
             NodeType::Hyperlane(inner) => serialize_compound("hyperlane", inner, serializer),
-            NodeType::MishtiNetwork(inner) => serialize_compound("mishti", inner, serializer),
-            NodeType::DittoNetwork(inner) => serialize_compound("ditto", inner, serializer),
+            NodeType::MishtiNetwork(inner) => {
+                serialize_compound("mishti-network", inner, serializer)
+            }
+            NodeType::DittoNetwork(inner) => serialize_compound("ditto-network", inner, serializer),
             // Simple types - use Display implementation
             _ => serializer.serialize_str(&self.to_string()),
         }
@@ -274,6 +276,8 @@ impl<'de> Deserialize<'de> for NodeType {
                 "hyperlane" => parse_inner(inner).map(NodeType::Hyperlane),
                 "mishti" => parse_inner(inner).map(NodeType::MishtiNetwork),
                 "ditto" => parse_inner(inner).map(NodeType::DittoNetwork),
+                "mishtinetwork" => parse_inner(inner).map(NodeType::MishtiNetwork),
+                "dittonetwork" => parse_inner(inner).map(NodeType::DittoNetwork),
                 _ => Err(D::Error::custom(format!(
                     "Invalid compound NodeType {normalized_outer}({})",
                     inner
@@ -823,6 +827,9 @@ mod node_type_tests {
             ("skate-chain(base)", NodeType::SkateChain(SkateChainType::Base)),
             ("skate-chain(mantle)", NodeType::SkateChain(SkateChainType::Mantle)),
             ("skate-chain(unknown-l2)", NodeType::SkateChain(SkateChainType::UnknownL2)),
+            ("ditto-network(unknown)", NodeType::DittoNetwork(ActiveSet::Unknown)),
+            ("ditto-network(eigenlayer)", NodeType::DittoNetwork(ActiveSet::Eigenlayer)),
+            ("ditto-network(symbiotic)", NodeType::DittoNetwork(ActiveSet::Symbiotic)),
         ];
 
         for (input, expected) in test_cases {


### PR DESCRIPTION
This pull request includes several changes to improve error handling, remove debugging prints, and enhance serialization and deserialization for node types. Below are the most important changes:

### Error Handling Improvement:
* [`cli/src/telemetry/docker_event_stream_listener.rs`](diffhunk://#diff-22b73972f520d761f56667d1f8ad7ab622eed240cc27ab01800a989978287bacL111-R113): Added error handling for `ask_send_machine_data` method to log errors when sending machine data fails.

### Debugging Prints Removal:
* [`db/src/avs.rs`](diffhunk://#diff-47902d0a62dcd4db7a03ee734bbcf51c52d5e3b5ba23784ef17365e97fd12db0L265-L267): Removed multiple `println!` statements used for debugging purposes in the `Avs` implementation. [[1]](diffhunk://#diff-47902d0a62dcd4db7a03ee734bbcf51c52d5e3b5ba23784ef17365e97fd12db0L265-L267) [[2]](diffhunk://#diff-47902d0a62dcd4db7a03ee734bbcf51c52d5e3b5ba23784ef17365e97fd12db0L276)

### Serialization and Deserialization Enhancements:
* [`ivynet-node-type/src/lib.rs`](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3L241-R244): Updated serialization for `MishtiNetwork` and `DittoNetwork` to use hyphenated names, and added support for deserializing these names with and without hyphens. [[1]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3L241-R244) [[2]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R279-R280)
* [`ivynet-node-type/src/lib.rs`](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R830-R832): Added new test cases for the updated serialization and deserialization logic for `DittoNetwork`.