### PR TITLE
Lagrange changed version strategy to latest instaed of mainnet/holesky

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,7 +2853,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "ivynet-backend"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "ivynet-ingress"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "db",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-backend"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 repository.workspace = true
 categories.workspace = true

--- a/db/src/data/avs_version.rs
+++ b/db/src/data/avs_version.rs
@@ -78,8 +78,7 @@ impl From<&NodeType> for VersionType {
 impl VersionType {
     pub fn fixed_name(node_type: &NodeType, chain: &Chain) -> Option<&'static str> {
         match (node_type, chain) {
-            (NodeType::LagrangeZkWorker, Chain::Holesky) => Some("holesky"),
-            (NodeType::LagrangeZkWorker, Chain::Mainnet) => Some("mainnet"),
+            (NodeType::LagrangeZkWorker, _) => Some("latest"),
             (NodeType::LagrangeZKProver, _) => Some("latest"),
             (NodeType::Gasp, _) => Some("latest"),
             (NodeType::K3LabsAvs, _) => Some("latest"),

--- a/ingress/Cargo.toml
+++ b/ingress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-ingress"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 repository.workspace = true
 categories.workspace = true


### PR DESCRIPTION
This pull request includes updates to version numbers and a change in the `fixed_name` method for `VersionType`.

Version updates:

* [`backend/Cargo.toml`](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1L3-R3): Updated the version from `0.5.1` to `0.5.2`.
* [`ingress/Cargo.toml`](diffhunk://#diff-a6e34b8a8edc3a53839a8e5e959a00f79f5dd6cd5df1fe9c6559c03bf8e3cdaeL3-R3): Updated the version from `0.5.1` to `0.5.2`.

Method changes:

* [`db/src/data/avs_version.rs`](diffhunk://#diff-ed1951db49cc0ee01924c8e73980c255dc0a20f0ac45f53ca0c52b82fde314caL81-R81): Modified the `fixed_name` method in the `impl From<&NodeType> for VersionType` to return "latest" for `NodeType::LagrangeZkWorker` regardless of the `Chain`.