### PR TITLE
Monitor now updates manifest as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "bollard",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["Noah Foltz <noah@ivynet.dev>"]
 description = "CLI for Ivynet client"

--- a/cli/src/monitor.rs
+++ b/cli/src/monitor.rs
@@ -116,6 +116,19 @@ impl MonitorConfig {
         });
         self.store()
     }
+
+    pub fn update_container_manifest(
+        &mut self,
+        container_name: &str,
+        manifest: &ContainerId,
+    ) -> Result<(), MonitorConfigError> {
+        self.configured_avses.iter_mut().for_each(|avs| {
+            if avs.container_name == container_name {
+                avs.manifest = Some(manifest.clone());
+            }
+        });
+        self.store()
+    }
 }
 
 pub async fn rename_node(
@@ -209,7 +222,7 @@ pub async fn start_monitor(config: IvyConfig) -> Result<(), anyhow::Error> {
     );
 
     info!("Starting monitor listener...");
-    listen(backend_client, machine, &monitor_config.configured_avses).await?;
+    listen(backend_client, machine, monitor_config).await?;
     Ok(())
 }
 


### PR DESCRIPTION
This pull request includes updates to the `cli` package to enhance functionality and improve code consistency. The most significant changes involve updating the version number, adding a new method to the `MonitorConfig` struct, and modifying the `listen` function to utilize the new method.

Version update:

* [`cli/Cargo.toml`](diffhunk://#diff-6057d83fb675b27e99f187fa354690b6597018c390cbd50eac854a56233d2addL3-R3): Updated the version from `0.5.2` to `0.5.3`.

Enhancements to `MonitorConfig`:

* [`cli/src/monitor.rs`](diffhunk://#diff-72dc46435f48526af8e2081f40a27adc77b66dc42ecf11918f9271652fea4982R119-R131): Added a new method `update_container_manifest` to the `MonitorConfig` struct to update the manifest of a specific container.

Modifications to `listen` function:

* [`cli/src/monitor.rs`](diffhunk://#diff-72dc46435f48526af8e2081f40a27adc77b66dc42ecf11918f9271652fea4982L212-R225): Changed the `start_monitor` function to pass the entire `monitor_config` instead of just the `configured_avses` to the `listen` function.
* [`cli/src/telemetry/mod.rs`](diffhunk://#diff-89b34d6cde084c8db08259b1afb0a4c0d75dcd76379e2ba6435de84b1d0eb359L169-R169): Updated the `listen` function to accept a `MonitorConfig` object and utilize the new `update_container_manifest` method to update container manifests during execution. [[1]](diffhunk://#diff-89b34d6cde084c8db08259b1afb0a4c0d75dcd76379e2ba6435de84b1d0eb359L169-R169) [[2]](diffhunk://#diff-89b34d6cde084c8db08259b1afb0a4c0d75dcd76379e2ba6435de84b1d0eb359R190-R209) [[3]](diffhunk://#diff-89b34d6cde084c8db08259b1afb0a4c0d75dcd76379e2ba6435de84b1d0eb359L214-R238)

Import adjustments:

* [`cli/src/telemetry/mod.rs`](diffhunk://#diff-89b34d6cde084c8db08259b1afb0a4c0d75dcd76379e2ba6435de84b1d0eb359L23-R23): Added `MonitorConfig` to the import list to support the changes in the `listen` function.