### PR TITLE
add b7s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "ivynet-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "dialoguer",
  "dirs",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "ivynet-docker-registry"
-version = "0.1.0"
+version = "0.5.1"
 dependencies = [
  "docker-registry",
  "ivynet-node-type",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "ivynet-node-type"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "convert_case",
  "serde",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-core"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Noah Foltz <noah@ivynet.dev>"]
 description = "Core library for Ivynet client functionality"

--- a/core/src/directory.rs
+++ b/core/src/directory.rs
@@ -109,12 +109,13 @@ const ALL_MAINNET_AVSES: [(NodeType, H160); 44] = [
     (NodeType::ZKLink, h160!(0x213F448e7a1C8DAEDe41cf94883Cc6149244d00F)),
     (NodeType::HyveDA, h160!(0xe3a148b25cca54eccbd3a4ab01e235d154f03efa)),
     (NodeType::Redstone, h160!(0x6f943318b05ad7c6ee596a220510a6d64b518dd8)),
+    // (NodeType::BlessB7s, h160!(0x0000000000000000000000000000000000000000)),
 ];
 
 /*------------------------------------------------
 ----------------HOLESKY AVS ----------------------
 --------------------------------------------------*/
-const ALL_HOLESKY_AVSES: [(NodeType, H160); 34] = [
+const ALL_HOLESKY_AVSES: [(NodeType, H160); 35] = [
     (NodeType::EigenDA, h160!(0xD4A7E1Bd8015057293f0D0A557088c286942e84b)),
     (NodeType::LagrangeStateCommittee, h160!(0x18A74E66cc90F0B1744Da27E72Df338cEa0A542b)),
     (NodeType::LagrangeZkWorker, h160!(0xf98d5de1014110c65c51b85ea55f73863215cc10)),
@@ -169,6 +170,7 @@ const ALL_HOLESKY_AVSES: [(NodeType, H160); 34] = [
         NodeType::MishtiNetwork(ActiveSet::Eigenlayer),
         h160!(0xe87ff321F5721a9285Ec651d01c0C0B857430c2c),
     ),
+    (NodeType::BlessB7s, h160!(0x234c91abd960b72e63d5e63c8246a259f3827ac8)),
 ];
 
 type AvsMap = HashMap<Chain, HashMap<NodeType, H160>>;

--- a/db/src/data/avs_version.rs
+++ b/db/src/data/avs_version.rs
@@ -21,6 +21,7 @@ pub enum VersionType {
 impl From<&NodeType> for VersionType {
     fn from(node_type: &NodeType) -> Self {
         match node_type {
+            NodeType::BlessB7s => VersionType::SemVer,
             NodeType::Tanssi => VersionType::FixedVer,
             NodeType::Bolt(_) => VersionType::SemVer,
             NodeType::Zellular => VersionType::FixedVer,

--- a/ivynet-docker-registry/Cargo.toml
+++ b/ivynet-docker-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-docker-registry"
-version = "0.1.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Noah Foltz <noah@ivynet.dev>"]
 description = "Docker library for IvyNet node detection and management"

--- a/ivynet-docker-registry/src/registry.rs
+++ b/ivynet-docker-registry/src/registry.rs
@@ -13,7 +13,14 @@ pub trait ImageRegistry {
 
 impl ImageRegistry for NodeType {
     fn registry(&self) -> Result<RegistryType, NodeTypeError> {
+        if self == &NodeType::BlessB7s {
+            println!("bless: {:?}", self);
+        } else if self == &NodeType::Unknown {
+            println!("unknown: {:?}", self);
+        }
+
         let res = match self {
+            Self::BlessB7s => Github,
             Self::Tanssi => DockerHub,
             Self::Redstone => Othentic,
             Self::Bolt(_) => Github,

--- a/ivynet-node-type/Cargo.toml
+++ b/ivynet-node-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ivynet-node-type"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Noah Foltz <noah@ivynet.dev>"]
 description = "Library for supported node types"

--- a/ivynet-node-type/src/lib.rs
+++ b/ivynet-node-type/src/lib.rs
@@ -101,6 +101,7 @@ pub enum NodeType {
     IBTCNetwork,
     ZKLink,
     HyveDA,
+    BlessB7s,
 }
 
 impl IntoEnumIterator for NodeType {
@@ -148,6 +149,7 @@ impl IntoEnumIterator for NodeType {
             NodeType::ZKLink,
             NodeType::HyveDA,
             NodeType::PrimevBidder,
+            NodeType::BlessB7s,
         ]
         .into_iter()
         .chain(ActiveSet::iter().map(NodeType::Hyperlane))
@@ -325,6 +327,7 @@ pub const ZELLULAR_REPO: &str = "zellular/zsequencer"; //Testnet only
 pub const BOLT_REPO: &str = "chainbound/bolt-sidecar"; //Testnet only
 pub const CYCLE_REPO: &str = "cycle-data-availability"; //Testnet only
 pub const TANSSI_REPO: &str = "moondancelabs/dancebox-container-chain-evm-templates"; //Testnet only
+pub const BLESS_B7S_REPO: &str = "blocklessnetwork/b7s";
 
 /* ------------------------------------ */
 /* ------- NODE CONTAINER NAMES ------- */
@@ -377,6 +380,7 @@ pub const BOLT_CONTAINER_NAME: &str = "bolt-sidecar-holesky";
 impl NodeType {
     pub fn default_repository(&self) -> Result<&'static str, NodeTypeError> {
         let res = match self {
+            Self::BlessB7s => BLESS_B7S_REPO,
             Self::Tanssi => TANSSI_REPO,
             Self::Cycle => CYCLE_REPO,
             Self::Zellular => ZELLULAR_REPO,
@@ -468,6 +472,7 @@ impl NodeType {
             Self::GoPlusAVS => GOPLUS_CONTAINER_NAME,
             Self::UngateInfiniRoute(_) => UNGATE_MAINNET,
             Self::DittoNetwork(_) => DITTO_NETWORK_CONTAINER_NAME,
+            Self::BlessB7s => return Err(NodeTypeError::NoDefaultContainerName),
             Self::PrimevMevCommit(_) => return Err(NodeTypeError::NoDefaultContainerName),
             Self::PrimevBidder => PRIMEV_BIDDER_CONTAINER_NAME,
             Self::Altlayer(altlayer_type) => {
@@ -549,6 +554,7 @@ impl NodeType {
             Self::LagrangeStateCommittee => LAGRANGE_STATE_COMMITTEE_CONTAINER_NAME,
             Self::LagrangeZkWorker => LAGRANGE_WORKER_CONTAINER_NAME,
             Self::Nuffle => NUFFLE_CONTAINER_NAME,
+            Self::BlessB7s => return Err(NodeTypeError::NoDefaultContainerName),
             Self::PrimevMevCommit(_) => return Err(NodeTypeError::NoDefaultContainerName),
             Self::PrimevBidder => PRIMEV_BIDDER_CONTAINER_NAME,
             Self::LagrangeZKProver => {
@@ -636,6 +642,7 @@ impl NodeType {
     pub fn from_repo(repo: &str) -> Option<Self> {
         debug!("repo: {}", repo);
         match repo {
+            BLESS_B7S_REPO => Some(Self::BlessB7s),
             ATLAS_NETWORK_REPO => Some(Self::AtlasNetwork),
             AVAPROTOCOL_REPO => Some(Self::AvaProtocol),
             EIGENDA_REPO => Some(Self::EigenDA),
@@ -830,6 +837,7 @@ mod node_type_tests {
             ("ditto-network(unknown)", NodeType::DittoNetwork(ActiveSet::Unknown)),
             ("ditto-network(eigenlayer)", NodeType::DittoNetwork(ActiveSet::Eigenlayer)),
             ("ditto-network(symbiotic)", NodeType::DittoNetwork(ActiveSet::Symbiotic)),
+            ("bless-b7s", NodeType::BlessB7s),
         ];
 
         for (input, expected) in test_cases {
@@ -907,6 +915,7 @@ mod node_type_tests {
             ("HyperLane(Unknown)", NodeType::Hyperlane(ActiveSet::Unknown)),
             ("HYPERLANE(EIGENLAYER)", NodeType::Hyperlane(ActiveSet::Eigenlayer)),
             ("HyperLane(Eigenlayer)", NodeType::Hyperlane(ActiveSet::Eigenlayer)),
+            ("BLEsSB7S", NodeType::BlessB7s),
         ];
 
         for (input, expected) in test_cases {

--- a/ivynet-node-type/src/restaking_protocol.rs
+++ b/ivynet-node-type/src/restaking_protocol.rs
@@ -47,6 +47,7 @@ impl RestakingProtocol for NodeType {
             NodeType::AtlasNetwork => RestakingProtocolType::Eigenlayer,
             NodeType::Zellular => RestakingProtocolType::Eigenlayer,
             NodeType::Redstone => RestakingProtocolType::Eigenlayer,
+            NodeType::BlessB7s => RestakingProtocolType::Eigenlayer,
             //Symbiotic
             NodeType::Cycle => RestakingProtocolType::Symbiotic,
             NodeType::Tanssi => RestakingProtocolType::Symbiotic,


### PR DESCRIPTION
This pull request introduces several updates and new features across multiple files, primarily focusing on adding support for a new node type, `BlessB7s`, and updating version numbers for various packages. Below are the most important changes:

### New Node Type: `BlessB7s`

* Added `BlessB7s` to the `NodeType` enum in `ivynet-node-type/src/lib.rs`, including its default repository and container name handling. [[1]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R104) [[2]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R152) [[3]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R330) [[4]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R383) [[5]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R475) [[6]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R557) [[7]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R645)
* Updated the `VersionType` enum and its `From` implementation to handle `BlessB7s` in `db/src/data/avs_version.rs`.
* Modified the `ImageRegistry` trait implementation to include logging for `BlessB7s` in `ivynet-docker-registry/src/registry.rs`.
* Updated the `RestakingProtocol` implementation to support `BlessB7s` in `ivynet-node-type/src/restaking_protocol.rs`.
* Added test cases for `BlessB7s` in `ivynet-node-type/src/lib.rs`. [[1]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R840) [[2]](diffhunk://#diff-cbcfef11963550cd4b4e9c1cfd19d10b9df5c5d97580e4274731ca175bcdb2a3R918)

### Version Updates

* Updated the version of `ivynet-core` from `0.5.1` to `0.5.2` in `core/Cargo.toml`.
* Updated the version of `ivynet-docker-registry` from `0.1.0` to `0.5.1` in `ivynet-docker-registry/Cargo.toml`.
* Updated the version of `ivynet-node-type` from `0.5.0` to `0.5.1` in `ivynet-node-type/Cargo.toml`.

### Directory Updates

* Added `BlessB7s` to the `ALL_HOLESKY_AVSES` array and commented it out in `ALL_MAINNET_AVSES` in `core/src/directory.rs`. [[1]](diffhunk://#diff-bef971be0e73c6412e1012f9fb52311c61ca6080a05b5e6dba9bb10edb9968e8R112-R118) [[2]](diffhunk://#diff-bef971be0e73c6412e1012f9fb52311c61ca6080a05b5e6dba9bb10edb9968e8R173)